### PR TITLE
aws/vpc: Add private subnet tags to terraform

### DIFF
--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -18,4 +18,10 @@ module "vpc" {
     "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
   }
 
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb"                  = 1
+    "kubernetes.io/cluster/${module.eks.cluster_name}" = "owned"
+  }
+
+
 }


### PR DESCRIPTION
If a cluster is set up to be internal-facing, the load balancer controller logs the following error: 
```
"error":"couldn't auto-discover subnets: unable to resolve at least one subnet
```

Per https://repost.aws/knowledge-center/eks-load-balancer-controller-subnets, "Resolve the single subnet discovery error", the private subnets must be tagged.