### PR TITLE
[OPAL-9456] Pin db engine version to 15.5

### DIFF
--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -25,6 +25,7 @@ resource "aws_db_instance" "opal" {
   identifier = var.db_identifier
 
   engine            = "postgres"
+  engine_version    = "15.5"
   allocated_storage = 50
   storage_type      = "gp3"
   instance_class    = var.db_instance_class


### PR DESCRIPTION
# Description

While we were working on setting up a new on-prem instance to test another project, when the environment was spun up, it was using the 16.1 postgres version. We were having trouble spinning up pods and realized this was a [known issue](https://github.com/ent/ent/issues/3752).

Since the version of Atlas we're on doesn't support 16.1, these changes pin the postgres version to 15.5. Our other on-prem testing instance is using that version just fine. The work to upgrade Atlas so we can eventually use postgres 16+ is tracked with OPAL-9457.

The impact is if any customers try to set up an instance right now, they won't be able to spin up the pods 😬 They'll need to either modify the terraform and re-run or manually create a db instance with the right version. They would get an error like the following when spinning up the pods:
```
Error: postgres: unexpected number of rows: 1
``` 

# Testing

- Ran `terraform validate`: Success! The configuration is valid.
- Ran `aws rds describe-db-engine-versions --engine postgres --region us-west-2 --engine-version 15` to get the appropriate versions:
```
            "Engine": "postgres",
            "EngineVersion": "15.5",
            "DBParameterGroupFamily": "postgres15",
            "DBEngineDescription": "PostgreSQL",
            "DBEngineVersionDescription": "PostgreSQL 15.5-R2",
``` 
- Ran `terraform plan` (snippet below):
```
  + resource "aws_db_instance" "opal" {
      + address                               = (known after apply)
      + allocated_storage                     = 50
      + apply_immediately                     = false
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + backup_retention_period               = 30
      + backup_window                         = (known after apply)
      + ca_cert_identifier                    = (known after apply)
      + character_set_name                    = (known after apply)
      + copy_tags_to_snapshot                 = false
      + db_name                               = "opal"
      + db_subnet_group_name                  = "opal"
      + delete_automated_backups              = true
      + endpoint                              = (known after apply)
      + engine                                = "postgres"
      + engine_version                        = "15.5"
```

# Risk

 - Low