### PR TITLE
[OPAL-9829] Bump to pg 15.6 for rds instance

### DIFF
--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "opal" {
   identifier = var.db_identifier
 
   engine            = "postgres"
-  engine_version    = "15.5"
+  engine_version    = "15.6"
   allocated_storage = 50
   storage_type      = "gp3"
   instance_class    = var.db_instance_class


### PR DESCRIPTION
## Description

We'll be upgrading our static postgres dbs to version 15.6 soon, so we want to standardize on this specific version across all instances of opal. This change ensures any new on-prem installs (or anyone who happens to update using this repo) will use 15.6 as well.

## Release Notes Description

Updates database instance's postgres version to 15.6

## Risk

Low, a minor version bump for postgres shouldn't have any incompatible changes, and should be very low impact.

## Testing

Validate:
```
$ terraform validate
Success! The configuration is valid.
```

Plan:
<details>
<summary>db-relevant snippet</summary>

```
  # aws_db_instance.opal will be created
  + resource "aws_db_instance" "opal" {
      + address                               = (known after apply)
      + allocated_storage                     = 50
      + apply_immediately                     = false
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + backup_retention_period               = 30
      + backup_window                         = (known after apply)
      + ca_cert_identifier                    = (known after apply)
      + character_set_name                    = (known after apply)
      + copy_tags_to_snapshot                 = false
      + db_name                               = "opal"
      + db_subnet_group_name                  = "opal"
      + delete_automated_backups              = true
      + endpoint                              = (known after apply)
      + engine                                = "postgres"
      + engine_version                        = "15.6"
      + engine_version_actual                 = (known after apply)
      + hosted_zone_id                        = (known after apply)
      + id                                    = (known after apply)
      + identifier                            = "opal"
      + identifier_prefix                     = (known after apply)
      + instance_class                        = "db.m5.large"
      + iops                                  = (known after apply)
      + kms_key_id                            = (known after apply)
      + latest_restorable_time                = (known after apply)
      + license_model                         = (known after apply)
      + listener_endpoint                     = (known after apply)
      + maintenance_window                    = (known after apply)
      + master_user_secret                    = (known after apply)
      + master_user_secret_kms_key_id         = (known after apply)
      + monitoring_interval                   = 0
      + monitoring_role_arn                   = (known after apply)
      + multi_az                              = true
      + name                                  = (known after apply)
      + nchar_character_set_name              = (known after apply)
      + network_type                          = (known after apply)
      + option_group_name                     = (known after apply)
      + parameter_group_name                  = (known after apply)
      + password                              = (sensitive value)
      + performance_insights_enabled          = false
      + performance_insights_kms_key_id       = (known after apply)
      + performance_insights_retention_period = (known after apply)
      + port                                  = (known after apply)
      + publicly_accessible                   = false
      + replica_mode                          = (known after apply)
      + replicas                              = (known after apply)
      + resource_id                           = (known after apply)
      + skip_final_snapshot                   = true
      + snapshot_identifier                   = (known after apply)
      + status                                = (known after apply)
      + storage_encrypted                     = true
      + storage_throughput                    = (known after apply)
      + storage_type                          = "gp3"
      + tags_all                              = (known after apply)
      + timezone                              = (known after apply)
      + username                              = "postgres"
      + vpc_security_group_ids                = (known after apply)
    }
```

</details>


## Checklist

- [X] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
