### PR TITLE
[OPAL-9452] Update default EKS version, instance size

### DIFF
--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,12 +13,12 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  default     = "1.26"
+  default     = "1.29"
   description = "EKS cluster version"
 }
 
 variable "cluster_node_instance_type" {
-  default     = "m5.large"
+  default     = "m6i.large"
   description = "EKS cluster node instance type"
 }
 
@@ -28,6 +28,6 @@ variable "db_identifier" {
 }
 
 variable "db_instance_class" {
-  default     = "db.m5.large"
+  default     = "db.m6i.large"
   description = "DB instance class"
 }


### PR DESCRIPTION
## Description

- Updates EKS default version to 1.29
- Use newer instance sizes for nodes and database by default (`m5` -> `m6i`)
## Release Notes Description

<!-- For bug fixes, new features, or any changes that impact customers, write a customer-facing description of your change that will be included in our release notes -->
- Update default EKS version, instance size

## Risk

> What is the level of risk to the product with this change? And why? (Low, High)

low, this only impacts new clusters

## Testing

n/a
## Checklist

- [x] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [X] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
