### PR TITLE
[SI-572] Disable EKS cluster public API access

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -60,8 +60,10 @@ module "eks" {
   cluster_version = var.cluster_version
 
   #networking
-  subnet_ids = module.vpc.private_subnets
-  vpc_id     = module.vpc.vpc_id
+  subnet_ids                      = module.vpc.private_subnets
+  vpc_id                          = module.vpc.vpc_id
+  cluster_endpoint_public_access  = false
+  cluster_endpoint_private_access = true
 
   //enable logs and OIDC
   cluster_enabled_log_types = ["audit", "api", "authenticator"]


### PR DESCRIPTION
## Description

Updates the eks config to make the cluster's API server private, instead of public. We already do this for all our normal EKS clusters; this is just updating the config we use for our internal clusters, and that we suggest to on-prem customers.

## Release Notes Description

n/a

## Risk

> What is the level of risk to the product with this change? And why? (Low, High)

Low

> If "High", what monitoring do we have in place to let us know if something goes wrong?

## Testing

Tested this on my test on-prem cluster

## Checklist

- [X] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
