### PR TITLE
[SI-708] update eks cluster admin role and policy

### DIFF
--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -14,12 +14,12 @@ data "aws_iam_policy_document" "opal_assume_role_policy" {
 
 #admin
 resource "aws_iam_role" "eks_cluster_admin" {
-  name                 = "OpalEKSClusterAdmin"
+  name                 = "${var.cluster_name}-OpalEKSClusterAdmin"
   assume_role_policy   = data.aws_iam_policy_document.opal_assume_role_policy.json
   max_session_duration = 1 * 60 * 60
 }
 resource "aws_iam_policy" "eks_cluster_admin" {
-  name   = "OpalEKSClusterAdminAccess"
+  name   = "${var.cluster_name}-OpalEKSClusterAdminAccess"
   policy = <<EOF
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
update eks cluster admin role and policy with variable to prevent users from having to manually do this in the future.

## Description
<!-- Write a brief description of your change here. If this change has UI impact, add a screenshot or a video! -->
Previously you'd have to manually change the names for the EKS Cluster Admin role and policy because they already exist, this should prevent that by using the cluster name variable as a prefix.

## Release Notes Description

<!-- For bug fixes, new features, or any changes that impact customers, write a customer-facing description of your change that will be included in our release notes -->

## Risk

> What is the level of risk to the product with this change? And why? (Low, High)
n/a
<!-- High areas of risk would include on-prem customers needing to re-run TF-->

> If "High", what monitoring do we have in place to let us know if something goes wrong?

## Testing
n/a
<!-- List out your test cases and include output from `terraform validate` and `terraform plan` -->

## Checklist
n/a
- [ ] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
