### PR TITLE
[SI-711] Upgrade default RDS and EKS versions

### DIFF
--- a/aws/rds.tf
+++ b/aws/rds.tf
@@ -25,7 +25,7 @@ resource "aws_db_instance" "opal" {
   identifier = var.db_identifier
 
   engine            = "postgres"
-  engine_version    = "15.6"
+  engine_version    = "15.10"
   allocated_storage = 50
   storage_type      = "gp3"
   instance_class    = var.db_instance_class

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 }
 
 variable "cluster_version" {
-  default     = "1.29"
+  default     = "1.32"
   description = "EKS cluster version"
 }
 


### PR DESCRIPTION
## Description

I believe postgres 15.6 is not supported any more, and kubernetes 1.29 is going EOL

## Release Notes Description

n/a

## Risk

> What is the level of risk to the product with this change? And why? (Low, High)

Low

<!-- High areas of risk would include on-prem customers needing to re-run TF-->

> If "High", what monitoring do we have in place to let us know if something goes wrong?

## Testing

<!-- List out your test cases and include output from `terraform validate` and `terraform plan` -->

## Checklist

- [ ] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
