### PR TITLE
[SI-813] Adds persistent volumes for nodes

### DIFF
--- a/aws/eks.tf
+++ b/aws/eks.tf
@@ -100,6 +100,18 @@ module "eks" {
     # the VPC CNI fails to assign IPs and nodes cannot join the new cluster
     # see https://github.com/aws/containers-roadmap/issues/1666 for more context
     iam_role_attach_cni_policy = true
+
+    # Creates persistent volumes
+    block_device_mappings = {
+      "xvda" = {
+        device_name = "/dev/xvda"
+
+        ebs = {
+          volume_size = 60
+          volume_type = "gp3"
+        }
+      }
+    }
   }
 
   #allow node to node communication and rds access


### PR DESCRIPTION
## Description

Adds a persistent volume for nodes that are being spun up when creating an on-prem deployment. 

## Release Notes Description

n/a
## Risk

> What is the level of risk to the product with this change? And why? (Low, High)

Low
> If "High", what monitoring do we have in place to let us know if something goes wrong?

## Testing

Was able to use this to create my own onprem cluster: rishikesh.opal.dev

## Checklist

- [ ] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
