### PR TITLE
[OPAL-13587] Swap opal-onprem to prlint gha

### DIFF
--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -1,0 +1,15 @@
+name: PR Lint
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+    branches-ignore:
+        - "**/graphite-base/**"
+
+jobs:
+  prlint-reloaded:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: maor-rozenfeld/prlint-reloaded@b8556615cddc303d112042c52c15c56fb7b829ee
+        with:
+          title-regex: "^(\\[((OPAL|DF|COR|SI|LPPM|IT|DOC)-([1-9][0-9]*)|Graphite MQ)\\]) (.+)"
+          error-message: "Title needs to be prefixed with a linear ticket [{team_id}-{ticket_number}]"


### PR DESCRIPTION
## Description
Same as https://app.graphite.dev/github/pr/opalsecurity/opal/17932/%5BOPAL-13586%5D-Use-prlint-reloaded-github-actions-version but for opal-onprem

## Release Notes Description
N/A

## Risk

> What is the level of risk to the product with this change? And why? (Low, High)

<!-- High areas of risk would include on-prem customers needing to re-run TF-->

> If "High", what monitoring do we have in place to let us know if something goes wrong?

## Testing
N/A

## Checklist

- [ ] I followed [PR best practices](https://www.notion.so/Pull-Request-Guidelines-972e273236ed46bc80f012bbab87b9fe) and performed a self-review of my code
- [ ] I updated our [external documentation](https://docs.opal.dev/docs) (if applicable add links below):
